### PR TITLE
Look for checkstyle.xml in project directory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ tasks.withType(FindBugs) {
 
 tasks.withType(Checkstyle) {
   checkstyle {
-    configFile = new File("${rootDir}/config/checkstyle/checkstyle.xml")
+    configFile = new File("${projectDir}/config/checkstyle/checkstyle.xml")
     ignoreFailures = true
     showViolations = false
   }


### PR DESCRIPTION
In case flux is added as a subproject rootDir will point to the wrong
directory, projectDir should be right for standalone or subproject.
